### PR TITLE
fix: remove reference to bot github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This is so that the `semantic-release` job in the `release` workflow doesn't fail from the `Error: Input required and not supplied: token` error. (see https://github.com/AdGem/Android-Example/actions/runs/8287401259 for more details)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release workflow configuration for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->