### PR TITLE
fix: use appropriate git author and committer references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_BOT_GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: ${{ vars.BOT_USERNAME }}
+          GIT_AUTHOR_NAME: ${{ vars.PUBLIC_BOT_USERNAME }}
           GIT_AUTHOR_EMAIL: ${{ vars.PUBLIC_BOT_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ vars.BOT_USERNAME }}
+          GIT_COMMITTER_NAME: ${{ vars.PUBLIC_BOT_USERNAME }}
           GIT_COMMITTER_EMAIL: ${{ vars.PUBLIC_BOT_EMAIL }}
         run: npx semantic-release
 


### PR DESCRIPTION
This is in reference to the issue in this failed GitHub Action Execution: https://github.com/AdGem/Android-Example/actions/runs/8513760987/job/23318140358: 
```
fatal: empty ident name (for <public-repo-sdk-developers@adgem.com>) not allowed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment variables for Git author and committer names in the GitHub release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->