### PR TITLE
fix: reference build gradle file with appropriate kotlin file extension

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,11 +24,11 @@ platform :android do
 
     # set the version code and version name
     android_set_version_code(
-      gradle_file: 'build.gradle'
+      gradle_file: 'build.gradle.kts'
     )
     android_set_version_name(
       version_name: options[:version],
-      gradle_file: 'build.gradle'
+      gradle_file: 'build.gradle.kts'
     )
   end
 


### PR DESCRIPTION
This is because of the failed `fastlane-release` job
https://github.com/AdGem/Android-Example/actions/runs/8514054806/job/23319058112
```
[21:39:41]: Error setting value 'build.gradle' for option 'gradle_file'
[21:39:41]: You passed invalid parameters to 'android_set_version_code'.
[21:39:41]: Check out the error below and available options by running `fastlane action android_set_version_code`
+------------------------------------+
|            Lane Context            |
+------------------+-----------------+
| DEFAULT_PLATFORM | android         |
| PLATFORM_NAME    | android         |
| LANE_NAME        | android release |
+------------------+-----------------+
[21:39:41]: Could not find app build.gradle file
```