### PR TITLE
fix: replace playstore distribution with distribution to firebase

### DIFF
--- a/.github/workflows/fastlane-release-and-distribute.yml
+++ b/.github/workflows/fastlane-release-and-distribute.yml
@@ -1,4 +1,4 @@
-name: fastlane-deploy
+name: fastlane-deploy-and-distribute
 
 on:
   workflow_call:
@@ -27,7 +27,7 @@ jobs:
           bundle install
           bundle exec fastlane release version:$GITHUB_REF_NAME
 
-  fastlane-deploy:
+  fastlane-distribute:
     needs: fastlane-release
     runs-on: ubuntu-latest
     steps:
@@ -44,4 +44,6 @@ jobs:
       - name: Run Fastlane
         run: |
           bundle install
-          bundle exec fastlane playstore
+          bundle exec fastlane distribute
+        env:
+          GH_TOKEN: ${{ secrets.PUBLIC_REPO_BOT_GITHUB_TOKEN }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,13 +32,33 @@ platform :android do
     )
   end
 
-  lane :playstore do
-    gradle(
-      task: 'assemble',
-      build_type: 'Release'
+  desc "Distribute builds via firebase"
+  lane :firebase do
+    app = "1:1037242127081:android:e6c38b03a4e11e46119678"
+    credentials = "./app/google-services.json"
+
+    # For firebase app distribution, we just use relative incremental numbers
+    latest_release = firebase_app_distribution_get_latest_release(
+      app: app,
+      service_credentials_file: credentials
     )
 
-    upload_to_play_store
+    release = get_github_release(
+      url: "AdGem/Android-Example",
+      version: options[:version],
+      api_token: ENV['GH_TOKEN']
+    )
+
+    gradle(
+      task: ":app:clean :app:build"
+    )
+
+    firebase_app_distribution(
+      app: app,
+      service_credentials_file: credentials
+      groups: "qa-testers",
+      release_notes: release["body"]
+    )
   end
 
 end


### PR DESCRIPTION
A conversation with Nick highlighted the lack of need for distribution to the Google Play Store and the iOS App Store. We still need these demo/example apps distributed to developers though, and that will be done through Firebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow and job names in GitHub Actions for clarity and better alignment with the deployment process.
- **New Features**
	- Enhanced app distribution process to include Firebase App Distribution, allowing for more streamlined sharing and testing of builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->