### PR TITLE
fix: surround firebase secret with quotation marks

### DIFF
--- a/.github/workflows/fastlane-release-and-distribute.yml
+++ b/.github/workflows/fastlane-release-and-distribute.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Add Firebase Service Account to play store json credentials file
         run: |
           mkdir -p fastlane/gcp
-          echo ${{ secrets.FIREBASE_SERVICE_ACCOUNT }} > fastlane/gcp/android-sdk-play-store.json
+          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}" > fastlane/gcp/android-sdk-play-store.json
       - name: Checkout code
         uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Context: We were getting this error in our `fastlane-release-and-distribute` Workflow: 
```
/home/runner/work/_temp/9aaa7cdd-75cf-4995-a15d-b2f0623b3252.sh: line 3: type:: command not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the reliability of app distribution through updates to the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->