### PR TITLE
refactor: add java gradle and ruby gems caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       
     # Run Tests Build
     - name: Run gradle tests
-      run: ./gradlew :app:clean :app:test
+      run: ./gradlew :app:test
 
     # Run Build Project
     - name: Build gradle project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
+        cache: 'gradle'
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'microsoft'
       
@@ -31,9 +32,6 @@ jobs:
     # Set Repository Name As Env Variable
     - name: Set repository name as env variable
       run: echo "repository_name=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
-
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
       
     # Run Tests Build
     - name: Run gradle tests

--- a/.github/workflows/fastlane-release-and-distribute.yml
+++ b/.github/workflows/fastlane-release-and-distribute.yml
@@ -22,9 +22,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
+          bundler-cache: true
       - name: Run Fastlane
         run: |
-          bundle install
           bundle exec fastlane release version:$GITHUB_REF_NAME
 
   fastlane-distribute:
@@ -43,9 +43,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
+          bundler-cache: true
       - name: Run Fastlane
         run: |
-          bundle install
           bundle exec fastlane firebase --verbose
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_REPO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Add caching mechanisms to Java/Gradle and Ruby/Bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved CI build times by adding caching for Gradle and enabling bundler caching for Ruby in GitHub workflows.
	- Enhanced GitHub workflow setup for smoother Java build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->