### PR TITLE
ci: use deps prefix for Dependabot and allow it in PR title lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: "build(actions-deps)"
-      prefix-development: "build(actions-deps-dev)"
+      prefix: "deps(actions-deps)"
+      prefix-development: "deps(actions-deps-dev)"
     rebase-strategy: "disabled"
 
 
@@ -24,6 +24,6 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: "build(gradle-deps)"
-      prefix-development: "build(gradle-deps-dev)"
+      prefix: "deps(gradle-deps)"
+      prefix-development: "deps(gradle-deps-dev)"
     rebase-strategy: "disabled"

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -29,5 +29,6 @@ jobs:
             test
             style
             perf
+            deps
           validateSingleCommit: true
 


### PR DESCRIPTION
Standardize Dependabot to the `deps` commit prefix and allow `deps` in the PR-title lint (dropping `chore` where present). Part of an org-wide cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request title validation workflows to recognize dependency-related commit types.
  * Standardized commit message prefixes for automated dependency updates across multiple ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->