### PR TITLE
refactor: migrate build scripts to plugins DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,4 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.12.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id("com.android.application") version "8.12.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include(":app")


### PR DESCRIPTION
## Summary
- Replaced legacy `buildscript`/`classpath` pattern with `plugins` DSL block in root `build.gradle.kts`
- Moved repository declarations from `allprojects` block to `dependencyResolutionManagement` in `settings.gradle.kts` with `FAIL_ON_PROJECT_REPOS` mode
- Added `pluginManagement` block for plugin repository resolution

Follow-up to #99 — these patterns (`buildscript`/`classpath`, `allprojects`) are deprecated in Gradle 9.x and on the path to removal.

## Test plan
- [ ] Verify project syncs and builds successfully
- [ ] Run integration tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to use modern Kotlin DSL syntax for improved maintainability and clearer dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->