### PR TITLE
refactor: bump compileSdk to 36 and migrate to compilerOptions DSL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.adgem.example"
-    compileSdk = 34
+    compileSdk = 36
     defaultConfig {
         applicationId = "com.adgem.android.example"
         minSdk = 21
@@ -21,8 +21,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Bumped `compileSdk` from 34 to 36 to unblock dependencies requiring API 36 (e.g. `androidx.core:core:1.18.0+`)
- Migrated from deprecated `kotlinOptions { jvmTarget }` to `kotlin { compilerOptions { jvmTarget.set(...) } }` DSL, required by Kotlin 2.3+

Unblocks the following Dependabot PRs:
- #100 (Material 1.14.0) — needs compileSdk 36
- #101 (AdGem 4.2.3) — needs compileSdk 36
- #102 (Kotlin 2.3.21) — needs compilerOptions DSL

## Test plan
- [ ] Verify project syncs and builds successfully
- [ ] Run integration tests to confirm no regressions
- [ ] After merge, rebase #100, #101, and #102 to verify they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app build configuration to target a newer Android API level, enhancing compatibility with the latest Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->