### PR TITLE
build: bump minSdk from 21 to 23

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 36
     defaultConfig {
         applicationId = "com.adgem.android.example"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
         versionCode = 18
         versionName = "1.18"


### PR DESCRIPTION
## Summary
- Bumped `minSdk` from 21 to 23, dropping Android 5.0-5.1 support (<1% of active devices)
- Required by AdGem SDK 4.2.3 which raised its minimum SDK to 23

Unblocks #101 (AdGem 4.0.3 → 4.2.3).

## Test plan
- [ ] Verify project builds successfully
- [ ] After merge, rebase #101 to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Android version support requirement for app installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->