### PR TITLE
build: bump targetSdk to 36, update README, and add version sync

### DIFF
--- a/.github/workflows/sync-readme-version.yml
+++ b/.github/workflows/sync-readme-version.yml
@@ -19,6 +19,10 @@ jobs:
         id: version
         run: |
           VERSION=$(grep 'com.adgem:adgem-android:' app/build.gradle.kts | sed 's/.*adgem-android:\([^"]*\)".*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Failed to extract AdGem SDK version from app/build.gradle.kts" >&2
+            exit 1
+          fi
           echo "sdk_version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update README with current version

--- a/.github/workflows/sync-readme-version.yml
+++ b/.github/workflows/sync-readme-version.yml
@@ -1,0 +1,40 @@
+name: Sync README version
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "app/build.gradle.kts"
+
+permissions:
+  contents: write
+
+jobs:
+  sync-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract AdGem SDK version from build.gradle.kts
+        id: version
+        run: |
+          VERSION=$(grep 'com.adgem:adgem-android:' app/build.gradle.kts | sed 's/.*adgem-android:\([^"]*\)".*/\1/')
+          echo "sdk_version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update README with current version
+        run: |
+          SDK_VERSION="${{ steps.version.outputs.sdk_version }}"
+          sed -i "s/com\.adgem:adgem-android:[0-9]\+\.[0-9]\+\.[0-9]\+/com.adgem:adgem-android:${SDK_VERSION}/g" README.md
+          sed -i "s|<version>[0-9]\+\.[0-9]\+\.[0-9]\+</version>|<version>${SDK_VERSION}</version>|" README.md
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git diff --quiet README.md || {
+            git add README.md
+            git commit -m "docs: sync README AdGem SDK version to ${SDK_VERSION} [skip ci]"
+            git push
+          }
+        env:
+          SDK_VERSION: ${{ steps.version.outputs.sdk_version }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download
 
 Gradle:
 ```groovy
-implementation 'com.adgem:adgem-android:4.0.3'
+implementation 'com.adgem:adgem-android:4.2.3'
 ```
 
 Maven:
@@ -19,7 +19,7 @@ Maven:
 <dependency>
   <groupId>com.adgem</groupId>
   <artifactId>adgem-android</artifactId>
-  <version>4.0.1</version>
+  <version>4.2.3</version>
   <type>pom</type>
 </dependency>
 ```
@@ -32,7 +32,7 @@ compileOptions {
 }
 ```
 
-AdGem Android SDK requires a minimum of Android 5.0.
+AdGem Android SDK requires a minimum of Android 6.0 (API 23).
 
 Overview
 --------

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "com.adgem.android.example"
         minSdk = 23
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 18
         versionName = "1.18"
     }


### PR DESCRIPTION
## Summary
- Bumped `targetSdk` from 34 to 36 to meet Google Play requirements
- Updated README.md: SDK version references (4.0.3/4.0.1 → 4.2.3) and minimum Android version (5.0 → 6.0 / API 23)
- Added `sync-readme-version.yml` workflow that auto-updates README version references whenever `app/build.gradle.kts` changes on master — no more stale version strings after Dependabot bumps

Closes #51

## Test plan
- [ ] Verify project builds with targetSdk 36
- [ ] Confirm README reflects correct versions
- [ ] Verify sync workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SDK dependency to 4.2.3
  * Raised minimum Android API level requirement to 23
  * Increased target Android SDK to 36

* **Chores**
  * Added automated workflow to keep README dependency/version references in sync with builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->