### PR TITLE
build: add Dependabot version-update cooldown (7d; 30d majors)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: "monthly"
@@ -20,6 +22,9 @@ updates:
 
   # Maintain dependencies for Gradle
   - package-ecosystem: "gradle"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Adds a `cooldown` block to every `updates:` entry so Dependabot **version
updates** wait ~1 week after a dependency release before opening a PR:

```yaml
cooldown:
  default-days: 7
  semver-major-days: 30   # SemVer-aware ecosystems only
```

**Why:** defense-in-depth against supply-chain 0-days — a malicious new
release gets a soak window for the community to catch it before we adopt it.

**Note:** cooldown applies to version updates only. Dependabot **security
updates** (known-CVE fixes) bypass the delay and still arrive immediately.

Part of org-wide rollout — Linear PLA-272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UzX2QJe4qqMQYNiZddawD