### PR TITLE
feat: adopt AdGem Android SDK 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Register the class in your `AndroidManifest.xml`:
 
 > **Upgrading from 4.x:** `res/xml/adgem_config.xml` and the `com.adgem.Config` manifest
 > meta-data are no longer read. Delete both and pass your App ID through `AdGemConfig.Builder`.
-> The `offerwallEnabled` and `lockOrientation` options have no 5.x equivalent.
+> The `offerwallEnabled`, `lockOrientation` and `debuggable` options have no 5.x equivalent.
 
 Call `close()` on logout, or before re-initializing with a different configuration.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download
 
 Gradle:
 ```groovy
-implementation 'com.adgem:adgem-android:4.2.3'
+implementation 'com.adgem:adgem-android:5.0.0'
 ```
 
 Maven:
@@ -19,7 +19,7 @@ Maven:
 <dependency>
   <groupId>com.adgem</groupId>
   <artifactId>adgem-android</artifactId>
-  <version>4.2.3</version>
+  <version>5.0.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -32,23 +32,44 @@ compileOptions {
 }
 ```
 
-AdGem Android SDK requires a minimum of Android 6.0 (API 23).
+Requirements
+--------
+
+| | |
+|---|---|
+| Minimum Android | 6.0 (API 23) |
+| `compileSdk` | 37 or later |
+| Android Gradle plugin | 9.1.0 or later |
+
+The `compileSdk` and AGP floors come from `androidx.core:core-ktx:1.19.0`, which the SDK depends
+on — AGP 8.x builds fail to resolve it. AGP 9 supplies Kotlin itself, so a project that applied
+`org.jetbrains.kotlin.android` must drop that plugin when it upgrades; see
+[AGP built-in Kotlin](https://kotl.in/gradle/agp-built-in-kotlin).
 
 Overview
 --------
-AdGem Android SDK library is automatically downloaded by the build system. To configure SDK for your project:
-1. Add ```adgem_config.xml``` to ```res/xml``` folder of your project structure:
-```xml
-<adgem-configuration 
-            applicationId="ADGEM_APP_ID"
-            offerwallEnabled="true|false" 
-            lockOrientation="true|false" />
+The SDK is initialized explicitly. Call `initialize` once before any other AdGem call —
+typically in `Application.onCreate()`:
+
+```kotlin
+class ExampleApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AdGem.get().initialize(this, AdGemConfig.Builder("ADGEM_APP_ID").build())
+    }
+}
 ```
-2. Add following tag to ```<application>``` to the ```AndroidManifest.xml```:
+
+Register the class in your `AndroidManifest.xml`:
 ```xml
-<meta-data android:name="com.adgem.Config"
-           android:resource="@xml/adgem_config"/>
+<application android:name=".ExampleApplication" ... >
 ```
+
+> **Upgrading from 4.x:** `res/xml/adgem_config.xml` and the `com.adgem.Config` manifest
+> meta-data are no longer read. Delete both and pass your App ID through `AdGemConfig.Builder`.
+> The `offerwallEnabled` and `lockOrientation` options have no 5.x equivalent.
+
+Call `close()` on logout, or before re-initializing with a different configuration.
 
 R8/ProGuard
 --------
@@ -63,16 +84,19 @@ AdGem adgem = AdGem.get();
 There is no need to store instance of AdGem globally. The SDK will cache the instance on a first call and will always return the same one for all subsequent calls to ```AdGem.get();```
 
 ### Player Metadata:
-For increased fraud protection, we require you set the `playerId`  (a unique id for your user) parameter.
+For increased fraud protection, we require you set the `playerId` (a unique id for your user,
+max 256 characters) parameter. Call `setPlayer` once the player identity is known — this may be
+at startup or later, e.g. after login.
+
 ```java
-  PlayerMetadata player = new PlayerMetadata.Builder.createWithPlayerId("myPlayerId")
+  PlayerMetadata player = new PlayerMetadata.Builder("myPlayerId")
     .age(23)
     .iapTotalUsd(10)
     .level(4)
     .placement(2)
     .isPayer(true)
     .gender(PlayerMetadata.Gender.FEMALE)
-    .createdAt("2018-11-16 06:23:19.07")
+    .createdAt(new Date())
     .customField1("custom_field_1")
     .customField2("custom_field_2")
     .customField3("custom_field_3")
@@ -80,19 +104,19 @@ For increased fraud protection, we require you set the `playerId`  (a unique id 
     .customField5("custom_field_5")
     .build();
 
-  adgem.setPlayerMetaData(player);
+  adgem.setPlayer(player);
 ```
+
+`createdAt` takes a `java.util.Date` and is serialized in UTC. Values outside the documented
+bounds are logged and skipped rather than sent.
+
+> **Upgrading from 4.x:** `Builder.createWithPlayerId()` and the no-arg `Builder()` are replaced
+> by `Builder(String playerId)`; `setPlayerMetaData()` is now `setPlayer()`; `createdAt` takes a
+> `Date` instead of a `String`.
 
 ### Offer Wall:
-AdGem will download and prepare the Offer Wall as it is configured in AdGem configuration XML:
-```xml
-<adgem-configuration 
-  ...
-  offerWallEnabled="true|false"
-  ... />
-```
-
-Once the Offer Wall is ready, AdGem will notify a subscriber via the ```OfferWallCallback```:
+Once the Offer Wall is ready, AdGem will notify a subscriber via the ```OfferwallCallback```.
+Every method has a default implementation, so override only the ones you need:
 ```java
   OfferwallCallback callback = new OfferwallCallback() {
       @Override
@@ -106,8 +130,10 @@ Once the Offer Wall is ready, AdGem will notify a subscriber via the ```OfferWal
       }
 
       @Override
-      public void onOfferwallLoadingFailed(String error) {
+      public void onOfferwallLoadingFailed(AdGemError error) {
           // Notifies that the offer wall has failed to load.
+          // Inspect error.getKind() to handle specific cases: NOT_INITIALIZED,
+          // NOT_READY, OFFERWALL_UNAVAILABLE, INTERNAL.
       }
 
       @Override
@@ -126,7 +152,9 @@ Offer wall callback may be registered through the instance of ```AdGem```:
 AdGem adgem = AdGem.get();
 adgem.registerOfferwallCallback(callback);
 ```
-Once registered, a callback will be used to deliver the offer wall updates.
+Once registered, a callback will be used to deliver the offer wall updates. All callback methods
+are invoked on the main thread, and `registerOfferwallCallback` / `unregisterOfferwallCallback`
+must themselves be called from the main thread.
 
 Keep in mind that AdGem will hold a strong reference to a callback. It is the caller’s responsibility to unregister it. For example, if a callback is being registered in activity’s `onCreate()` then it must be unregistered in corresponding `onDestroy()` call.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,10 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {
     namespace = "com.adgem.example"
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         applicationId = "com.adgem.android.example"
         minSdk = 23
@@ -14,7 +13,9 @@ android {
         versionName = "1.18"
     }
 
-    viewBinding.isEnabled = true
+    buildFeatures {
+        viewBinding = true
+    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -29,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation("com.adgem:adgem-android:4.2.3")
+    implementation("com.adgem:adgem-android:5.0.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.14.0")
     implementation("androidx.preference:preference-ktx:1.2.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
-    <application android:allowBackup="false"
+    <application android:name="com.adgem.example.ExampleApplication"
+                 android:allowBackup="false"
                  android:label="@string/app_name"
                  android:icon="@mipmap/ic_launcher"
                  android:roundIcon="@mipmap/ic_launcher_round"
@@ -18,9 +19,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-
-        <meta-data android:name="com.adgem.Config"
-                   android:resource="@xml/adgem_config"/>
 
     </application>
 

--- a/app/src/main/kotlin/com/adgem/example/AdGemActivity.kt
+++ b/app/src/main/kotlin/com/adgem/example/AdGemActivity.kt
@@ -7,10 +7,14 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import com.adgem.android.AdGem
+import com.adgem.android.AdGemError
 import com.adgem.android.BuildConfig
 import com.adgem.android.OfferwallCallback
 import com.adgem.android.PlayerMetadata
 import com.adgem.example.databinding.ActivityAdgemBinding
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.TimeZone
 import java.util.UUID
 
 class AdGemActivity : AppCompatActivity(), OfferwallCallback {
@@ -51,8 +55,8 @@ class AdGemActivity : AppCompatActivity(), OfferwallCallback {
         showMessage(R.string.offer_wall_closed_hint)
     }
 
-    override fun onOfferwallLoadingFailed(error: String?) {
-        error?.let { showMessage(it) }
+    override fun onOfferwallLoadingFailed(error: AdGemError) {
+        showMessage(getString(R.string.offer_wall_load_failed, error.kind.name, error.message))
     }
 
     private fun showMessage(@StringRes text: Int) {
@@ -73,9 +77,16 @@ class AdGemActivity : AppCompatActivity(), OfferwallCallback {
             sharedPreferences.edit().putString(playerIdKey, playerId).apply()
         }
 
-        val metadata = PlayerMetadata.Builder.createWithPlayerId(playerId)
+        // 5.0.0 takes a Date and serializes it in UTC, so pin the calendar to UTC to keep
+        // the wire value identical to the "2018-11-10 18:39:45" this used to send.
+        val createdAt = GregorianCalendar(TimeZone.getTimeZone("UTC")).apply {
+            clear()
+            set(2018, Calendar.NOVEMBER, 10, 18, 39, 45)
+        }.time
+
+        val metadata = PlayerMetadata.Builder(playerId)
             .age(32)
-            .createdAt("2018-11-10 18:39:45")
+            .createdAt(createdAt)
             .gender(PlayerMetadata.Gender.FEMALE)
             .iapTotalUsd(123f)
             .level(100)
@@ -86,6 +97,6 @@ class AdGemActivity : AppCompatActivity(), OfferwallCallback {
             .customField4("custom_field_4")
             .customField5("custom_field_5")
             .build()
-        AdGem.get().setPlayerMetaData(metadata)
+        adGem.setPlayer(metadata)
     }
 }

--- a/app/src/main/kotlin/com/adgem/example/ExampleApplication.kt
+++ b/app/src/main/kotlin/com/adgem/example/ExampleApplication.kt
@@ -1,0 +1,26 @@
+package com.adgem.example
+
+import android.app.Application
+import com.adgem.android.AdGem
+import com.adgem.android.AdGemConfig
+
+/**
+ * SDK 5.0.0 requires an explicit [AdGem.initialize] before any other AdGem call — the
+ * auto-init content provider and the `com.adgem.Config` manifest meta-data that earlier
+ * versions relied on are both gone. Doing it here means the SDK is ready before any
+ * activity starts.
+ *
+ * The player is identified separately, in [AdGemActivity], because a real host app only
+ * knows its player id once the user is known (e.g. after login).
+ */
+class ExampleApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AdGem.get().initialize(this, AdGemConfig.Builder(APP_ID).build())
+    }
+
+    companion object {
+        /** Each application must register its own applicationId with adgem.com. */
+        const val APP_ID = "282"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="error">Error</string>
     <string name="user_rewarded">User was rewarded with %1$d</string>
     <string name="offer_wall_closed_hint">Offer wall rewards may come in later</string>
+    <string name="offer_wall_load_failed">Offer wall failed (%1$s): %2$s</string>
 </resources>

--- a/app/src/main/res/xml/adgem_config.xml
+++ b/app/src/main/res/xml/adgem_config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Each application must register its own applicationId with adgem.com-->
-<adgem-configuration
-        applicationId="282"
-        offerwallEnabled="true"
-        debuggable="true"/>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
-    id("com.android.application") version "8.12.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    // AGP 9 provides Kotlin support itself; the standalone org.jetbrains.kotlin.android
+    // plugin must not be applied alongside it. See https://kotl.in/gradle/agp-built-in-kotlin
+    id("com.android.application") version "9.3.1" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
Part of PUB-262

Moves the example app onto the published `5.0.0` artifact from Maven Central and
migrates off the 4.x API the major release removed. This is the Android half of
PUB-262; the iOS half landed in AdGem/iOS-Sample-App#23.

## API migration

- **Explicit initialization.** 5.0.0 dropped the auto-init content provider and no
  longer reads `com.adgem.Config` / `res/xml/adgem_config.xml`. A new
  `ExampleApplication` calls `initialize(Context, AdGemConfig)` in `onCreate()` and
  carries the app id (`282`) that the deleted XML held. The player is still
  identified separately in `AdGemActivity`, which is what a real host app does — it
  only knows its player id once the user is known.
- `PlayerMetadata.Builder.createWithPlayerId()` → `Builder(playerId)`, and
  `setPlayerMetaData()` → `setPlayer()`.
- `onOfferwallLoadingFailed(String)` → `(AdGemError)`. The toast now shows
  `error.kind`, so the typed-error contract is actually visible when dogfooding.
- `offerwallEnabled` and `debuggable` from the old XML have no 5.x equivalent —
  `AdGemConfig` carries only the app id — so they are simply gone.

### `createdAt` is the one to look at

It went `String` → `Date`, and a naive conversion silently changes what goes on the
wire. The calendar is pinned to UTC to keep the value identical to the
`"2018-11-10 18:39:45"` this used to send. Confirmed empirically: the verification
emulator was on `America/La_Paz` (UTC−4) and still sent
`player_created_at=2018-11-10 18:39:45`. A local-time `Date` would have shifted it
four hours.

## The toolchain bump is not optional

`master` builds fine, and the dependency bump *alone* does not: SDK 5.0.0 depends on
`androidx.core:core-ktx:1.19.0`, which requires **AGP ≥ 9.1.0 and compileSdk ≥ 37**.
On AGP 8.12.2 the dependency does not resolve. That cascaded:

- AGP `8.12.2` → `9.3.1`, `compileSdk` `36` → `37`
- **`org.jetbrains.kotlin.android` removed**, not upgraded — AGP 9 supplies Kotlin
  itself and applying both is a hard error (`Cannot add extension with name 'kotlin'`).
  See [AGP built-in Kotlin](https://kotl.in/gradle/agp-built-in-kotlin).
- `viewBinding.isEnabled` → `buildFeatures { viewBinding = true }` (removed in AGP 9)
- dropped the deprecated `android.enableJetifier=true`, which cleared the last
  build warning

`targetSdk` stays at **36**. Bumping it is a runtime-behavior change and this repo
has handled that in dedicated PRs (#107).

> **Overlaps #118** (dependabot, AGP 8.12.2 → 9.3.1), and touches #114/#117's
> territory. Bundled here so this branch actually builds. Equally fine to land #118
> first and rebase this on top — the end state is identical. Reviewer's call.

## Worth raising separately (SDK-side)

The SDK only uses `ViewCompat`, `WindowInsetsCompat`, and `Insets`, all available in
much older `androidx.core`, and `library/` is pure Java so it does not need the
`-ktx` variant at all. Pinning `core-ktx:1.19.0` forces **every publisher** onto
AGP 9.1+/compileSdk 37 and drags in `kotlin-stdlib`. That is a real integration
barrier for anyone still on AGP 8.x, and it is not mentioned in the 5.0.0 release
notes.

## Test plan

- [x] `./gradlew :app:test` — green
- [x] `./gradlew :app:clean :app:build` (what CI runs) — green, **zero warnings**
- [x] Lint issue set unchanged vs `master`; `OldTargetApi`, `UnusedResources` and
      `UseKtx` all pre-date this branch
- [x] `debugRuntimeClasspath` resolves `com.adgem:adgem-android:5.0.0`
- [x] API 35 emulator: launches without crash, footer reads **`AdGem SDK v5.0.0`**
      — that string comes from the AAR's own `BuildConfig`, so the published binary
      is genuinely loaded — and no `initialize() called before…` warnings are logged
- [x] Offerwall opens and renders server-side UI, requesting
      `appid=282&sdk_version=5.0.0` with the full player metadata on the wire

- [x] Offerwall serves **real inventory** end to end: from a US egress the wall
      renders "Ringtones for Android" (42 gems), tagged `MOST POPULAR`, in both the
      All Offers and Trending tabs

The offerwall initially rendered its chrome with an empty offer list; that turned out
to be geo, not the integration — re-running from a US egress populated it. Inventory
is still thin (one offer) because `ad_tracking_enabled=0` on an emulator, which has
no usable Google Advertising ID, so most offers stay suppressed. A real device should
show more, and completing an offer is the one path this run cannot exercise.

Two emulator quirks in the logs, neither an integration fault: `v.adgem.com` fails to
resolve inside WebView (`-105`) even though `ping` resolves it — Chromium uses its own
DNS resolver, which the emulator's `-dns-server` does not reach — and that host is the
source of the `Error: probe` console noise. Offer content comes from
`adunits.adgem.com`, which resolves fine. `No available adapters` refers to
mediation/rewarded-video adapters, not offers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the example integration to AdGem SDK 5.0.0.
  * Added explicit SDK initialization and lifecycle handling.
  * Improved offerwall failure messages with error categories and details.
  * Updated player metadata configuration with validated player IDs and timestamps.

* **Documentation**
  * Added Android, compile SDK, and build tool requirements.
  * Documented SDK 4.x migration steps, callback updates, threading requirements, and logout or reinitialization guidance.
  * Replaced XML-based configuration instructions with the new initialization approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->